### PR TITLE
Add support for multiple encodings

### DIFF
--- a/examples/exampleRX.py
+++ b/examples/exampleRX.py
@@ -4,8 +4,8 @@ from rtpTTML import TTMLReceiver  # type: ignore
 
 
 class Receiver:
-    def __init__(self, port: int) -> None:
-        self.receiver = TTMLReceiver(port, self.processDoc)
+    def __init__(self, port: int, encoding: str) -> None:
+        self.receiver = TTMLReceiver(port, self.processDoc, encoding=encoding)
 
     def processDoc(self, doc: str, timestamp: int) -> None:
         print("{}\n".format(doc))
@@ -26,9 +26,16 @@ if __name__ == "__main__":
         type=int,
         help='receiver port',
         required=True)
+    parser.add_argument(
+        '-e',
+        '--encoding',
+        type=str,
+        default="utf-8",
+        help='Character encoding of document (default: utf-8)',
+        required=False)
     args = parser.parse_args()
 
-    rx = Receiver(args.port)
+    rx = Receiver(args.port, encoding=args.encoding)
 
     loop = asyncio.get_event_loop()
     loop.run_until_complete(rx.run())

--- a/examples/exampleTX.py
+++ b/examples/exampleTX.py
@@ -86,9 +86,10 @@ class DocGen:
 
 
 class Transmitter:
-    def __init__(self, address: str, port: int) -> None:
+    def __init__(self, address: str, port: int, encoding: str) -> None:
         self._address = address
         self._port = port
+        self._encoding = encoding
         flowid = uuid4()
         self._docGen = DocGen(flowid)
         self._running = False
@@ -98,7 +99,8 @@ class Transmitter:
 
     async def run(self) -> None:
         self._running = True
-        async with TTMLTransmitter(self._address, self._port) as transmitter:
+        async with TTMLTransmitter(
+           self._address, self._port, encoding=self._encoding) as transmitter:
             while self._running:
                 now = datetime.now()
                 doc = self._docGen.generateDoc(transmitter.nextSeqNum, str(now))
@@ -122,9 +124,16 @@ if __name__ == "__main__":
         type=int,
         help='receiver port',
         required=True)
+    parser.add_argument(
+        '-e',
+        '--encoding',
+        type=str,
+        default="utf-8",
+        help='Character encoding of document (default: utf-8)',
+        required=False)
     args = parser.parse_args()
 
-    tx = Transmitter(args.ip_address, args.port)
+    tx = Transmitter(args.ip_address, args.port, args.encoding)
 
     loop = asyncio.get_event_loop()
     task = loop.create_task(tx.run())

--- a/rtpTTML/ttmlReceiver.py
+++ b/rtpTTML/ttmlReceiver.py
@@ -84,11 +84,13 @@ class TTMLReceiver:
        port: int,
        callback: Callable[[str, int], None],
        recvBufSize: int = None,
-       timeout: Union[float, None] = None) -> None:
+       timeout: Union[float, None] = None,
+       encoding: str = "utf-8") -> None:
         self._fragments: Dict[int, RTP] = OrderedDict()
         self._curTimestamp = 0
         self._port = port
         self._callback = callback
+        self._encoding = encoding
         self._socket: Optional[socket.socket]
         self._transport: Optional[asyncio.DatagramTransport]
         self._protocol: Optional[TTMLDatagramProtocol]
@@ -167,7 +169,8 @@ class TTMLReceiver:
             seqNumber = self._unloopSeqNum(
                 max(self._fragments), packet.sequenceNumber)
 
-        payload = RTPPayload_TTML().fromBytearray(packet.payload)
+        payload = RTPPayload_TTML(encoding=self._encoding).fromBytearray(
+            packet.payload)
         self._fragments[seqNumber] = payload.userDataWords
 
     def _processData(self, data: bytes) -> None:

--- a/rtpTTML/ttmlTransmitter.py
+++ b/rtpTTML/ttmlTransmitter.py
@@ -78,11 +78,13 @@ class TTMLTransmitter:
        maxFragmentSize: int = 1200,
        payloadType: PayloadType = PayloadType.DYNAMIC_96,
        initialSeqNum: int = None,
-       tsOffset: Optional[int] = None) -> None:
+       tsOffset: Optional[int] = None,
+       encoding: str = "utf-8") -> None:
         self._address = address
         self._port = port
         self._maxFragmentSize = maxFragmentSize
         self._payloadType = payloadType
+        self._encoding = encoding
 
         if initialSeqNum is not None:
             self._nextSeqNum = initialSeqNum
@@ -130,7 +132,8 @@ class TTMLTransmitter:
 
         while True:
             thisEnd = thisStart + maxLen
-            while len(bytearray(doc[thisStart:thisEnd], "utf-8")) > maxLen:
+            while len(bytearray(doc[thisStart:thisEnd],
+                      self._encoding)) > maxLen:
                 thisEnd -= 1
 
             fragments.append(doc[thisStart:thisEnd])
@@ -153,7 +156,8 @@ class TTMLTransmitter:
         packet = RTP(
             timestamp=time,
             sequenceNumber=self._nextSeqNum,
-            payload=RTPPayload_TTML(userDataWords=doc).toBytearray(),
+            payload=RTPPayload_TTML(
+                userDataWords=doc, encoding=self._encoding).toBytearray(),
             marker=marker,
             payloadType=self._payloadType
         )


### PR DESCRIPTION
Following on from yesterdays PR, this adds support for multiple UTF encodings to the top-level rtpTTML library and examples.